### PR TITLE
Add google benchmark to cmake and add few benchmarks of searching

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(APPLE)
    set(CMAKE_CXX_COMPILER /usr/local/Homebrew/bin/g++-14)
 endif()
 
-project(collision_parser)
+project(collision_manager)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -21,28 +21,50 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g3")
 include(FetchContent)
 FetchContent_Declare(
   googletest
-  URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG v1.16.0
 )
 
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
-add_executable(main collision.cpp collision_parser.cpp collision_manager.cpp main.cpp)
+set(BENCHMARK_ENABLE_TESTING OFF)
+set(BENCHMARK_ENABLE_GTEST_TESTS OFF)
+set(BENCHMARK_ENABLE_ASSEMBLY_TESTS OFF)
+FetchContent_Declare(
+  benchmark
+  GIT_REPOSITORY https://github.com/google/benchmark.git
+  GIT_TAG v1.9.1
+)
 
-enable_testing()
+FetchContent_MakeAvailable(benchmark)
+
+add_library(collision_manager collision.cpp collision_parser.cpp collision_manager.cpp)
+add_executable(main main.cpp)
+target_link_libraries(main collision_manager)
 
 add_executable(
-  collion_manager_test
-  collision.cpp
-  collision_parser.cpp
-  collision_manager.cpp
+  collision_manager_test
   collision_manager_test.cpp
 )
 
 target_link_libraries(
-  collion_manager_test
+  collision_manager_test
+  collision_manager
   GTest::gtest_main
 )
 
+add_executable(
+  collision_manager_benchmark
+  collision_manager_benchmark.cpp
+)
+target_link_libraries(
+  collision_manager_benchmark
+  collision_manager
+  benchmark::benchmark_main
+)
+
+enable_testing()
+
 include(GoogleTest)
-gtest_discover_tests(collion_manager_test)
+gtest_discover_tests(collision_manager_test)

--- a/collision_manager_benchmark.cpp
+++ b/collision_manager_benchmark.cpp
@@ -1,0 +1,61 @@
+#include "collision_manager.hpp"
+
+#include <benchmark/benchmark.h>
+#include <limits>
+
+static std::unique_ptr<CollisionManager> collision_manager;
+
+class CollisionManagerBenchmark : public benchmark::Fixture
+{
+public:
+
+    void SetUp(const ::benchmark::State& state)
+    {
+        if (collision_manager.get() == nullptr) {
+            collision_manager = std::make_unique<CollisionManager>(std::string("../Motor_Vehicle_Collisions_-_Crashes_20250123.csv"));
+        }
+    }
+};
+
+BENCHMARK_DEFINE_F(CollisionManagerBenchmark, SearchSingleStringFieldNoMatches)(benchmark::State& state) {
+    Query query = Query::create("borough", QueryType::EQUALS, "Nothing should match me");
+
+    for (auto _ : state) {
+        std::vector<const Collision*> results = collision_manager->search(query);
+        benchmark::DoNotOptimize(results);
+    }
+}
+
+BENCHMARK_DEFINE_F(CollisionManagerBenchmark, SearchSingleStringFieldSomeMatches)(benchmark::State& state) {
+    Query query = Query::create("borough", QueryType::EQUALS, "BROOKLYN");
+
+    for (auto _ : state) {
+        std::vector<const Collision*> results = collision_manager->search(query);
+        benchmark::DoNotOptimize(results);
+    }
+}
+
+BENCHMARK_DEFINE_F(CollisionManagerBenchmark, SearchSingleSizeTFieldNoMatches)(benchmark::State& state) {
+    Query query = Query::create("zip_code", QueryType::EQUALS, std::numeric_limits<size_t>::max());
+
+    for (auto _ : state) {
+        std::vector<const Collision*> results = collision_manager->search(query);
+        benchmark::DoNotOptimize(results);
+    }
+}
+
+BENCHMARK_DEFINE_F(CollisionManagerBenchmark, SearchSingleSizeTFieldSomeMatches)(benchmark::State& state) {
+    Query query = Query::create("zip_code", QueryType::EQUALS, 11208ULL);
+
+    for (auto _ : state) {
+        std::vector<const Collision*> results = collision_manager->search(query);
+        benchmark::DoNotOptimize(results);
+    }
+}
+
+BENCHMARK_REGISTER_F(CollisionManagerBenchmark, SearchSingleStringFieldNoMatches)->Iterations(50);
+BENCHMARK_REGISTER_F(CollisionManagerBenchmark, SearchSingleStringFieldSomeMatches)->Iterations(50);
+BENCHMARK_REGISTER_F(CollisionManagerBenchmark, SearchSingleSizeTFieldNoMatches)->Iterations(50);
+BENCHMARK_REGISTER_F(CollisionManagerBenchmark, SearchSingleSizeTFieldSomeMatches)->Iterations(50);
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
```
$ mkdir b
$ cd b
$ cmake ..
$ make
$ ctest
$ ./collision_manager_benchmark
2025-02-12T13:23:27-08:00
Running ./collision_manager_benchmark
Run on (16 X 3992.24 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 1024 KiB (x8)
  L3 Unified 16384 KiB (x1)
Load Average: 0.18, 0.26, 0.24
***WARNING*** Library was built as DEBUG. Timings may be affected.
Too few fields on csv line: 09/06/2015,14:15,,,40.6722269,-74.0110059,"(40.6722269, -74.0110059)",,,"R/O 1 BEARD ST. ( IKEA'S
Too few fields on csv line:  PARKING LOT).",0,0,0,0,0,0,0,0,Unspecified,Unspecified,,,,3291249,PASSENGER VEHICLE,PASSENGER VEHICLE,,,
---------------------------------------------------------------------------------------------------------------------
Benchmark                                                                           Time             CPU   Iterations
---------------------------------------------------------------------------------------------------------------------
CollisionManagerBenchmark/SearchSingleStringFieldNoMatches/iterations:50    445583226 ns    445581666 ns           50
CollisionManagerBenchmark/SearchSingleStringFieldSomeMatches/iterations:50  422094417 ns    422097110 ns           50
CollisionManagerBenchmark/SearchSingleSizeTFieldNoMatches/iterations:50     199477315 ns    199524440 ns           50
CollisionManagerBenchmark/SearchSingleSizeTFieldSomeMatches/iterations:50   199037787 ns    199976506 ns           50
```