### PR TITLE
Phase_3.2: Precompute CollisionProxies during constructor rather than during search()

### DIFF
--- a/phase_3.2/collision_manager.hpp
+++ b/phase_3.2/collision_manager.hpp
@@ -13,7 +13,7 @@ public:
 
     bool is_initialized();
     const std::string& get_initialization_error();
-    const std::vector<CollisionProxy> searchOpenMp(const Query& query);
+    const std::vector<CollisionProxy*> searchOpenMp(const Query& query);
 
     friend class CollisionManagerTest;
 
@@ -22,8 +22,10 @@ private:
     CollisionManager(const std::vector<Collision>& collisions);
 
     const CollisionProxy index_to_collision(const std::size_t index);
+    void create_proxies();
 
     std::string initialization_error_;
     Collisions collisions_;
+    std::vector<CollisionProxy> collision_proxies_;
 
 };

--- a/phase_3.2/collision_manager_benchmark.cpp
+++ b/phase_3.2/collision_manager_benchmark.cpp
@@ -21,7 +21,7 @@ BENCHMARK_DEFINE_F(CollisionManagerBenchmark, SearchSingleStringFieldNoMatches)(
     Query query = Query::create("borough", QueryType::EQUALS, "Nothing should match me");
 
     for (auto _ : state) {
-        std::vector<CollisionProxy> results = collision_manager->searchOpenMp(query);
+        std::vector<CollisionProxy*> results = collision_manager->searchOpenMp(query);
         benchmark::DoNotOptimize(results);
     }
 }
@@ -30,7 +30,7 @@ BENCHMARK_DEFINE_F(CollisionManagerBenchmark, SearchSingleStringFieldSomeMatches
     Query query = Query::create("borough", QueryType::EQUALS, "BROOKLYN");
 
     for (auto _ : state) {
-        std::vector<CollisionProxy> results = collision_manager->searchOpenMp(query);
+        std::vector<CollisionProxy*> results = collision_manager->searchOpenMp(query);
         benchmark::DoNotOptimize(results);
     }
 }
@@ -39,7 +39,7 @@ BENCHMARK_DEFINE_F(CollisionManagerBenchmark, SearchSingleSizeTFieldNoMatches)(b
     Query query = Query::create("zip_code", QueryType::EQUALS, std::numeric_limits<size_t>::max());
 
     for (auto _ : state) {
-        std::vector<CollisionProxy> results = collision_manager->searchOpenMp(query);
+        std::vector<CollisionProxy*> results = collision_manager->searchOpenMp(query);
         benchmark::DoNotOptimize(results);
     }
 }
@@ -48,7 +48,7 @@ BENCHMARK_DEFINE_F(CollisionManagerBenchmark, SearchSingleSizeTFieldSomeMatches)
     Query query = Query::create("zip_code", QueryType::EQUALS, 11208ULL);
 
     for (auto _ : state) {
-        std::vector<CollisionProxy> results = collision_manager->searchOpenMp(query);
+        std::vector<CollisionProxy*> results = collision_manager->searchOpenMp(query);
         benchmark::DoNotOptimize(results);
     }
 }
@@ -58,7 +58,7 @@ BENCHMARK_DEFINE_F(CollisionManagerBenchmark, SearchLatitudeSomeMatches)(benchma
     Query query = Query::create("latitude", QueryType::EQUALS, latitude);
 
     for(auto _ : state) {
-        std::vector<CollisionProxy> results = collision_manager->searchOpenMp(query);
+        std::vector<CollisionProxy*> results = collision_manager->searchOpenMp(query);
         benchmark::DoNotOptimize(results);
     }
 }
@@ -68,7 +68,7 @@ BENCHMARK_DEFINE_F(CollisionManagerBenchmark, SearchLesserThanLatitudeSomeMatche
     Query query = Query::create("latitude", QueryType::LESS_THAN, latitude);
 
     for(auto _ : state) {
-        std::vector<CollisionProxy> results = collision_manager->searchOpenMp(query);
+        std::vector<CollisionProxy*> results = collision_manager->searchOpenMp(query);
         benchmark::DoNotOptimize(results);
     }
 }
@@ -78,7 +78,7 @@ BENCHMARK_DEFINE_F(CollisionManagerBenchmark, SearchGreaterThanLatitudeSomeMatch
     Query query = Query::create("latitude", QueryType::GREATER_THAN, latitude);
 
     for(auto _ : state) {
-        std::vector<CollisionProxy> results = collision_manager->searchOpenMp(query);
+        std::vector<CollisionProxy*> results = collision_manager->searchOpenMp(query);
         benchmark::DoNotOptimize(results);
     }
 }
@@ -88,7 +88,7 @@ BENCHMARK_DEFINE_F(CollisionManagerBenchmark, SearchLongitudeSomeMatches)(benchm
     Query query = Query::create("latitude", QueryType::EQUALS, longitude);
 
     for(auto _ : state) {
-        std::vector<CollisionProxy> results = collision_manager->searchOpenMp(query);
+        std::vector<CollisionProxy*> results = collision_manager->searchOpenMp(query);
         benchmark::DoNotOptimize(results);
     }
 }
@@ -98,7 +98,7 @@ BENCHMARK_DEFINE_F(CollisionManagerBenchmark, SearchLesserThanLongitudeSomeMatch
     Query query = Query::create("latitude", QueryType::LESS_THAN, longitude);
 
     for(auto _ : state) {
-        std::vector<CollisionProxy> results = collision_manager->searchOpenMp(query);
+        std::vector<CollisionProxy*> results = collision_manager->searchOpenMp(query);
         benchmark::DoNotOptimize(results);
     }
 }
@@ -108,7 +108,7 @@ BENCHMARK_DEFINE_F(CollisionManagerBenchmark, SearchGreaterThanLongitudeSomeMatc
     Query query = Query::create("latitude", QueryType::GREATER_THAN, longitude);
 
     for(auto _ : state) {
-        std::vector<CollisionProxy> results = collision_manager->searchOpenMp(query);
+        std::vector<CollisionProxy*> results = collision_manager->searchOpenMp(query);
         benchmark::DoNotOptimize(results);
     }
 }
@@ -119,7 +119,7 @@ BENCHMARK_DEFINE_F(CollisionManagerBenchmark, SearchBorough_LessThanLatitudeSome
     Query query = Query::create("latitude", QueryType::LESS_THAN, latitude).add("borough", QueryType::EQUALS, "BROOKLYN");
 
     for(auto _ : state) {
-        std::vector<CollisionProxy> results = collision_manager->searchOpenMp(query);
+        std::vector<CollisionProxy*> results = collision_manager->searchOpenMp(query);
         benchmark::DoNotOptimize(results);
     }
 }
@@ -133,7 +133,7 @@ BENCHMARK_DEFINE_F(CollisionManagerBenchmark, SearchRangeofCoordinatesSomeMatche
                       .add("longitude", QueryType::LESS_THAN, longitude);
 
     for(auto _ : state) {
-        std::vector<CollisionProxy> results = collision_manager->searchOpenMp(query);
+        std::vector<CollisionProxy*> results = collision_manager->searchOpenMp(query);
         benchmark::DoNotOptimize(results);
     }
 }
@@ -148,7 +148,7 @@ BENCHMARK_DEFINE_F(CollisionManagerBenchmark, SearchDatesEqualsSomeMatches)(benc
     Query query = Query::create("crash_date", QueryType::EQUALS, date1);
 
     for(auto _ : state) {
-        std::vector<CollisionProxy> results = collision_manager->searchOpenMp(query);
+        std::vector<CollisionProxy*> results = collision_manager->searchOpenMp(query);
         benchmark::DoNotOptimize(results);
     }
 }
@@ -170,7 +170,7 @@ BENCHMARK_DEFINE_F(CollisionManagerBenchmark, SearchDatesRangeSomeMatches)(bench
     Query query = Query::create("crash_date", QueryType::GREATER_THAN, date1).add("crash_date", QueryType::LESS_THAN, date2);
 
     for(auto _ : state) {
-        std::vector<CollisionProxy> results = collision_manager->searchOpenMp(query);
+        std::vector<CollisionProxy*> results = collision_manager->searchOpenMp(query);
         benchmark::DoNotOptimize(results);
     }
 }
@@ -202,7 +202,7 @@ BENCHMARK_DEFINE_F(CollisionManagerBenchmark, SearchRangeofCoordinates_DateRange
                       .add("crash_date", QueryType::LESS_THAN, date2);
 
     for(auto _ : state) {
-        std::vector<CollisionProxy> results = collision_manager->searchOpenMp(query);
+        std::vector<CollisionProxy*> results = collision_manager->searchOpenMp(query);
         benchmark::DoNotOptimize(results);
     }
 }

--- a/phase_3.2/collision_manager_test.cpp
+++ b/phase_3.2/collision_manager_test.cpp
@@ -103,7 +103,7 @@ TEST_F(CollisionManagerTest, MatchEmpty) {
 
     Query query = Query::create("borough", QueryType::EQUALS, "Nothing should match me");
 
-    std::vector<CollisionProxy> results = collision_manager.searchOpenMp(query);
+    std::vector<CollisionProxy*> results = collision_manager.searchOpenMp(query);
     EXPECT_EQ(results.size(), 0);
 }
 
@@ -116,11 +116,11 @@ TEST_F(CollisionManagerTest, MatchEquals) {
     CollisionManager collision_manager = create_collision_manager(collisions);
 
     Query query1 = Query::create("borough", QueryType::EQUALS, "Nothing should match me");
-    std::vector<CollisionProxy> results1 = collision_manager.searchOpenMp(query1);
+    std::vector<CollisionProxy*> results1 = collision_manager.searchOpenMp(query1);
     EXPECT_EQ(results1.size(), 0);
 
     Query query2 = Query::create("borough", QueryType::EQUALS, "BROOKLYN");
-    std::vector<CollisionProxy> results2 = collision_manager.searchOpenMp(query2);
+    std::vector<CollisionProxy*> results2 = collision_manager.searchOpenMp(query2);
     EXPECT_EQ(results2.size(), 1);
 }
 
@@ -143,30 +143,30 @@ TEST_F(CollisionManagerTest, CompoundMatchEquals) {
 
     Query query1 = Query::create("borough", QueryType::EQUALS, "BROOKLYN")
         .add("collision_id", QueryType::EQUALS, 10ULL);
-    std::vector<CollisionProxy> results1 = collision_manager.searchOpenMp(query1);
+    std::vector<CollisionProxy*> results1 = collision_manager.searchOpenMp(query1);
     EXPECT_EQ(results1.size(), 0);
 
     Query query2 = Query::create("borough", QueryType::EQUALS, "BROOKLYN")
         .add("collision_id", QueryType::EQUALS, 1ULL);
-    std::vector<CollisionProxy> results2 = collision_manager.searchOpenMp(query2);
+    std::vector<CollisionProxy*> results2 = collision_manager.searchOpenMp(query2);
     EXPECT_EQ(results2.size(), 1);
-    EXPECT_EQ(*results2[0].borough, "BROOKLYN");
-    EXPECT_EQ(*results2[0].collision_id, 1ULL);
+    EXPECT_EQ(*results2[0]->borough, "BROOKLYN");
+    EXPECT_EQ(*results2[0]->collision_id, 1ULL);
 
     Query query3 = Query::create("borough", QueryType::EQUALS, "QUEENS")
         .add("collision_id", QueryType::EQUALS, 3ULL);
-    std::vector<CollisionProxy> results3 = collision_manager.searchOpenMp(query3);
+    std::vector<CollisionProxy*> results3 = collision_manager.searchOpenMp(query3);
     EXPECT_EQ(results3.size(), 1);
-    EXPECT_EQ(*results3[0].borough, "QUEENS");
-    EXPECT_EQ(*results3[0].collision_id, 3ULL);
+    EXPECT_EQ(*results3[0]->borough, "QUEENS");
+    EXPECT_EQ(*results3[0]->collision_id, 3ULL);
 
     Query query4 = Query::create("borough", QueryType::EQUALS, "BROOKLYN");
-    std::vector<CollisionProxy> results4 = collision_manager.searchOpenMp(query4);
+    std::vector<CollisionProxy*> results4 = collision_manager.searchOpenMp(query4);
     EXPECT_EQ(results4.size(), 2);
-    EXPECT_EQ(*results4[0].borough, "BROOKLYN");
-    EXPECT_EQ(*results4[0].collision_id, 1ULL);
-    EXPECT_EQ(*results4[1].borough, "BROOKLYN");
-    EXPECT_EQ(*results4[1].collision_id, 2ULL);
+    EXPECT_EQ(*results4[0]->borough, "BROOKLYN");
+    EXPECT_EQ(*results4[0]->collision_id, 1ULL);
+    EXPECT_EQ(*results4[1]->borough, "BROOKLYN");
+    EXPECT_EQ(*results4[1]->collision_id, 2ULL);
 }
 
 TEST_F(CollisionManagerTest, MatchNotEquals) {
@@ -181,18 +181,18 @@ TEST_F(CollisionManagerTest, MatchNotEquals) {
     CollisionManager collision_manager = create_collision_manager(collisions);
 
     Query query1 = Query::create("borough", QueryType::EQUALS, "Nothing should match me");
-    std::vector<CollisionProxy> results1 = collision_manager.searchOpenMp(query1);
+    std::vector<CollisionProxy*> results1 = collision_manager.searchOpenMp(query1);
     EXPECT_EQ(results1.size(), 0);
 
     Query query2 = Query::create("borough", QueryType::EQUALS, "BROOKLYN");
-    std::vector<CollisionProxy> results2 = collision_manager.searchOpenMp(query2);
+    std::vector<CollisionProxy*> results2 = collision_manager.searchOpenMp(query2);
     EXPECT_EQ(results2.size(), 1);
-    EXPECT_EQ(*results2[0].borough, "BROOKLYN");
+    EXPECT_EQ(*results2[0]->borough, "BROOKLYN");
 
     Query query3 = Query::create("borough", Qualifier::NOT, QueryType::EQUALS, "BROOKLYN");
-    std::vector<CollisionProxy> results3 = collision_manager.searchOpenMp(query3);
+    std::vector<CollisionProxy*> results3 = collision_manager.searchOpenMp(query3);
     EXPECT_EQ(results3.size(), 1);
-    EXPECT_EQ(*results3[0].borough, "QUEENS");
+    EXPECT_EQ(*results3[0]->borough, "QUEENS");
 }
 
 TEST_F(CollisionManagerTest, MatchCaseInsensitive) {
@@ -207,18 +207,18 @@ TEST_F(CollisionManagerTest, MatchCaseInsensitive) {
     CollisionManager collision_manager = create_collision_manager(collisions);
 
     Query query1 = Query::create("borough", QueryType::EQUALS, "Nothing should match me");
-    std::vector<CollisionProxy> results1 = collision_manager.searchOpenMp(query1);
+    std::vector<CollisionProxy*> results1 = collision_manager.searchOpenMp(query1);
     EXPECT_EQ(results1.size(), 0);
 
     Query query2 = Query::create("borough", QueryType::EQUALS, "BROOKLYN");
-    std::vector<CollisionProxy> results2 = collision_manager.searchOpenMp(query2);
+    std::vector<CollisionProxy*> results2 = collision_manager.searchOpenMp(query2);
     EXPECT_EQ(results2.size(), 1);
-    EXPECT_EQ(*results2[0].borough, "BROOKLYN");
+    EXPECT_EQ(*results2[0]->borough, "BROOKLYN");
 
     Query query3 = Query::create("borough", QueryType::EQUALS, "brooklyn", Qualifier::CASE_INSENSITIVE);
-    std::vector<CollisionProxy> results3 = collision_manager.searchOpenMp(query3);
+    std::vector<CollisionProxy*> results3 = collision_manager.searchOpenMp(query3);
     EXPECT_EQ(results3.size(), 1);
-    EXPECT_EQ(*results3[0].borough, "BROOKLYN");
+    EXPECT_EQ(*results3[0]->borough, "BROOKLYN");
 
 }
 
@@ -237,7 +237,7 @@ TEST_F(CollisionManagerTest, MatchEqualsDate) {
     CollisionManager collision_manager = create_collision_manager(collisions);
 
     Query query1 = Query::create("crash_date", QueryType::EQUALS, date);
-    std::vector<CollisionProxy> results1 = collision_manager.searchOpenMp(query1);
+    std::vector<CollisionProxy*> results1 = collision_manager.searchOpenMp(query1);
     EXPECT_EQ(results1.size(), 1);
 }
 
@@ -263,7 +263,7 @@ TEST_F(CollisionManagerTest, MatchGreaterThanDate) {
     CollisionManager collision_manager = create_collision_manager(collisions);
 
     Query query = Query::create("crash_date", QueryType::GREATER_THAN, date1);
-    std::vector<CollisionProxy> results = collision_manager.searchOpenMp(query);
+    std::vector<CollisionProxy*> results = collision_manager.searchOpenMp(query);
     EXPECT_EQ(results.size(), 1);
 }
 
@@ -290,7 +290,7 @@ TEST_F(CollisionManagerTest, MatchLessThanDate) {
     CollisionManager collision_manager = create_collision_manager(collisions);
 
     Query query = Query::create("crash_date", QueryType::LESS_THAN, date1);
-    std::vector<CollisionProxy> results = collision_manager.searchOpenMp(query);
+    std::vector<CollisionProxy*> results = collision_manager.searchOpenMp(query);
     EXPECT_EQ(results.size(), 1);
 }
 
@@ -303,12 +303,12 @@ TEST_F(CollisionManagerTest, CSV_Query_MatchLessThanDate) {
     };
 
     Query query = Query::create("crash_date", QueryType::LESS_THAN, date1);
-    std::vector<CollisionProxy> results = collision_manager_m.searchOpenMp(query);
+    std::vector<CollisionProxy*> results = collision_manager_m.searchOpenMp(query);
 
     EXPECT_GT(results.size(), 0) << "Search should return at least one result";
 
-    for (const auto collision : results) {
-        EXPECT_TRUE(*collision.crash_date < date1)
+    for (const auto *collision : results) {
+        EXPECT_TRUE(*collision->crash_date < date1)
             << "Each result should have date less than " << date1;
     }
 
@@ -324,12 +324,12 @@ TEST_F(CollisionManagerTest, CSV_Query_MatchGreaterThanDate) {
     };
 
     Query query = Query::create("crash_date", QueryType::GREATER_THAN, date1);
-    std::vector<CollisionProxy> results = collision_manager_m.searchOpenMp(query);
+    std::vector<CollisionProxy*> results = collision_manager_m.searchOpenMp(query);
 
     EXPECT_GT(results.size(), 0) << "Search should return at least one result";
 
-    for (const auto collision : results) {
-        EXPECT_TRUE(*collision.crash_date > date1)
+    for (const auto *collision : results) {
+        EXPECT_TRUE(*collision->crash_date > date1)
             << "Each result should have date greater than " << date1;
     }
 
@@ -345,12 +345,12 @@ TEST_F(CollisionManagerTest, CSV_Query_MatchEqualsDate) {
     };
 
     Query query = Query::create("crash_date", QueryType::EQUALS, date1);
-    std::vector<CollisionProxy> results = collision_manager_m.searchOpenMp(query);
+    std::vector<CollisionProxy*> results = collision_manager_m.searchOpenMp(query);
 
     EXPECT_GT(results.size(), 0) << "Search should return at least one result";
 
-    for (const auto collision : results) {
-        EXPECT_TRUE(*collision.crash_date == date1)
+    for (const auto *collision : results) {
+        EXPECT_TRUE(*collision->crash_date == date1)
             << "Each result should have date greater than " << date1;
     }
 
@@ -364,12 +364,12 @@ TEST_F(CollisionManagerTest, CSV_Query_MatchEqualsTime) {
     };
 
     Query query = Query::create("crash_time", QueryType::EQUALS, time1);
-    std::vector<CollisionProxy> results = collision_manager_m.searchOpenMp(query);
+    std::vector<CollisionProxy*> results = collision_manager_m.searchOpenMp(query);
 
     EXPECT_GT(results.size(), 0) << "Search should return at least one result";
 
-    for (const auto collision : results) {
-        EXPECT_TRUE(collision.crash_time->has_value() && collision.crash_time->value().to_duration() == time1.to_duration())
+    for (const auto *collision : results) {
+        EXPECT_TRUE(collision->crash_time->has_value() && collision->crash_time->value().to_duration() == time1.to_duration())
             << "Each result should have time equal to " << time1;
     }
 
@@ -383,12 +383,12 @@ TEST_F(CollisionManagerTest, CSV_Query_MatchGreaterThanTime) {
     };
 
     Query query = Query::create("crash_time", QueryType::GREATER_THAN, time1);
-    std::vector<CollisionProxy> results = collision_manager_m.searchOpenMp(query);
+    std::vector<CollisionProxy*> results = collision_manager_m.searchOpenMp(query);
 
     EXPECT_GT(results.size(), 0) << "Search should return at least one result";
 
-    for (const auto collision : results) {
-        EXPECT_TRUE(collision.crash_time->has_value() && collision.crash_time->value().to_duration() > time1.to_duration())
+    for (const auto *collision : results) {
+        EXPECT_TRUE(collision->crash_time->has_value() && collision->crash_time->value().to_duration() > time1.to_duration())
             << "Each result should have time equal to " << time1;
     }
 
@@ -403,12 +403,12 @@ TEST_F(CollisionManagerTest, CSV_Query_MatchLessThanTime) {
     };
 
     Query query = Query::create("crash_time", QueryType::LESS_THAN, time1);
-    std::vector<CollisionProxy> results = collision_manager_m.searchOpenMp(query);
+    std::vector<CollisionProxy*> results = collision_manager_m.searchOpenMp(query);
 
     EXPECT_GT(results.size(), 0) << "Search should return at least one result";
 
-    for (const auto collision : results) {
-        EXPECT_TRUE(collision.crash_time->has_value() && collision.crash_time->value().to_duration() < time1.to_duration())
+    for (const auto *collision : results) {
+        EXPECT_TRUE(collision->crash_time->has_value() && collision->crash_time->value().to_duration() < time1.to_duration())
             << "Each result should have time equal to " << time1;
     }
 
@@ -420,14 +420,14 @@ TEST_F(CollisionManagerTest, CSV_Query_MatchEqualLatitude) {
     float latitude = 40.667202f;
 
     Query query = Query::create("latitude", QueryType::EQUALS, latitude);
-    std::vector<CollisionProxy> results = collision_manager_m.searchOpenMp(query);
+    std::vector<CollisionProxy*> results = collision_manager_m.searchOpenMp(query);
 
     EXPECT_GT(results.size(), 0) << "Search should return at least one result";
 
-    for (const auto collision : results)
+    for (const auto *collision : results)
     {
-       EXPECT_TRUE(collision.latitude->has_value());
-       EXPECT_NEAR(collision.latitude->value(), latitude,0.001f)
+       EXPECT_TRUE(collision->latitude->has_value());
+       EXPECT_NEAR(collision->latitude->value(), latitude,0.001f)
             << "Latitude values should be equal within floating-point precision";
     }
 
@@ -439,14 +439,14 @@ TEST_F(CollisionManagerTest, CSV_Query_MatchGreaterLatitude) {
     float latitude = 40.667202f;
 
     Query query = Query::create("latitude", QueryType::GREATER_THAN, latitude);
-    std::vector<CollisionProxy> results = collision_manager_m.searchOpenMp(query);
+    std::vector<CollisionProxy*> results = collision_manager_m.searchOpenMp(query);
 
     EXPECT_GT(results.size(), 0) << "Search should return at least one result";
 
-    for (const auto collision : results)
+    for (const auto *collision : results)
     {
-       EXPECT_TRUE(collision.latitude->has_value());
-       EXPECT_GT(collision.latitude->value(), latitude)
+       EXPECT_TRUE(collision->latitude->has_value());
+       EXPECT_GT(collision->latitude->value(), latitude)
             << "Latitude values should be equal within floating-point precision";
     }
 
@@ -458,14 +458,14 @@ TEST_F(CollisionManagerTest, CSV_Query_MatchLesserThanLatitude) {
     float latitude = 40.667202f;
 
     Query query = Query::create("latitude", QueryType::LESS_THAN, latitude);
-    std::vector<CollisionProxy> results = collision_manager_m.searchOpenMp(query);
+    std::vector<CollisionProxy*> results = collision_manager_m.searchOpenMp(query);
 
     EXPECT_GT(results.size(), 0) << "Search should return at least one result";
 
-    for (const auto collision : results)
+    for (const auto *collision : results)
     {
-       EXPECT_TRUE(collision.latitude->has_value());
-       EXPECT_LT(collision.latitude->value(), latitude)
+       EXPECT_TRUE(collision->latitude->has_value());
+       EXPECT_LT(collision->latitude->value(), latitude)
             << "Latitude values should be equal within floating-point precision";
     }
 
@@ -477,12 +477,12 @@ TEST_F(CollisionManagerTest, CSV_Query_MatchEqualsZipcode) {
     size_t zip_code = 11208;
 
     Query query = Query::create("zip_code", QueryType::EQUALS, zip_code);
-    std::vector<CollisionProxy> results = collision_manager_m.searchOpenMp(query);
+    std::vector<CollisionProxy*> results = collision_manager_m.searchOpenMp(query);
 
     EXPECT_GT(results.size(), 0) << "Search should return at least one result";
 
-    for (const auto collision : results) {
-        EXPECT_TRUE(collision.zip_code->value() == zip_code)
+    for (const auto *collision : results) {
+        EXPECT_TRUE(collision->zip_code->value() == zip_code)
             << "Each result should have zip_code equal to " << zip_code;
     }
 
@@ -498,12 +498,12 @@ TEST_F(CollisionManagerTest, CompoundQuery_Match_EqualsBorough_and_GreaterThanTi
 
     Query query1 = Query::create("borough", QueryType::EQUALS, borough).add("crash_time", QueryType::GREATER_THAN, crash_time);
 
-    std::vector<CollisionProxy> results = collision_manager_m.searchOpenMp(query1);
+    std::vector<CollisionProxy*> results = collision_manager_m.searchOpenMp(query1);
 
     EXPECT_GT(results.size(), 0) << "Search should return at least one result";
 
-    for (const auto collision : results) {
-        EXPECT_TRUE(collision.borough->value() == borough && collision.crash_time->has_value() && collision.crash_time->value().to_duration() > crash_time.to_duration())
+    for (const auto *collision : results) {
+        EXPECT_TRUE(collision->borough->value() == borough && collision->crash_time->has_value() && collision->crash_time->value().to_duration() > crash_time.to_duration())
             << "Each result should have borough equal to " << borough << " and " << "crash time greater than " << crash_time;
     }
 
@@ -520,12 +520,12 @@ TEST_F(CollisionManagerTest, CompoundQuery_Match_EqualsBorough_and_LesserThanTim
 
     Query query1 = Query::create("borough", QueryType::EQUALS, borough).add("crash_time", QueryType::LESS_THAN, crash_time);
 
-    std::vector<CollisionProxy> results = collision_manager_m.searchOpenMp(query1);
+    std::vector<CollisionProxy*> results = collision_manager_m.searchOpenMp(query1);
 
     EXPECT_GT(results.size(), 0) << "Search should return at least one result";
 
-    for (const auto collision : results) {
-        EXPECT_TRUE(collision.borough->value() == borough && collision.crash_time->has_value() && collision.crash_time->value().to_duration() < crash_time.to_duration())
+    for (const auto *collision : results) {
+        EXPECT_TRUE(collision->borough->value() == borough && collision->crash_time->has_value() && collision->crash_time->value().to_duration() < crash_time.to_duration())
             << "Each result should have borough equal to " << borough << " and " << "crash time lesser than " << crash_time;
     }
 
@@ -542,12 +542,12 @@ TEST_F(CollisionManagerTest, CompoundQuery_Match_EqualsZipCode_and_GreaterThanTi
 
     Query query1 = Query::create("zip_code", QueryType::EQUALS, zip_code).add("crash_time", QueryType::GREATER_THAN, crash_time);
 
-    std::vector<CollisionProxy> results = collision_manager_m.searchOpenMp(query1);
+    std::vector<CollisionProxy*> results = collision_manager_m.searchOpenMp(query1);
 
     EXPECT_GT(results.size(), 0) << "Search should return at least one result";
 
-    for (const auto collision : results) {
-        EXPECT_TRUE(collision.zip_code->value() == zip_code && collision.crash_time->has_value() && collision.crash_time->value().to_duration() > crash_time.to_duration())
+    for (const auto *collision : results) {
+        EXPECT_TRUE(collision->zip_code->value() == zip_code && collision->crash_time->has_value() && collision->crash_time->value().to_duration() > crash_time.to_duration())
             << "Each result should have zip_code equal to " << zip_code << " and " << "crash time greater than " << crash_time;
     }
 
@@ -564,12 +564,12 @@ TEST_F(CollisionManagerTest, CompoundQuery_Match_EqualsZipCode_and_LesserThanTim
 
     Query query1 = Query::create("zip_code", QueryType::EQUALS, zip_code).add("crash_time", QueryType::LESS_THAN, crash_time);
 
-    std::vector<CollisionProxy> results = collision_manager_m.searchOpenMp(query1);
+    std::vector<CollisionProxy*> results = collision_manager_m.searchOpenMp(query1);
 
     EXPECT_GT(results.size(), 0) << "Search should return at least one result";
 
-    for (const auto collision : results) {
-        EXPECT_TRUE(collision.zip_code->value() == zip_code && collision.crash_time->has_value() && collision.crash_time->value().to_duration() < crash_time.to_duration())
+    for (const auto *collision : results) {
+        EXPECT_TRUE(collision->zip_code->value() == zip_code && collision->crash_time->has_value() && collision->crash_time->value().to_duration() < crash_time.to_duration())
             << "Each result should have zip_code equal to " << zip_code << " and " << "crash time less than " << crash_time;
     }
 
@@ -604,15 +604,15 @@ TEST_F(CollisionManagerTest, CompoundQuery_Match_MutipleFields) {
     .add("borough", QueryType::EQUALS, borough)
     .add("number_of_persons_injured", QueryType::GREATER_THAN, persons_injured);
 
-    std::vector<CollisionProxy> results = collision_manager_m.searchOpenMp(query1);
+    std::vector<CollisionProxy*> results = collision_manager_m.searchOpenMp(query1);
 
     EXPECT_GT(results.size(), 0) << "Search should return at least one result";
 
-    for (const auto collision : results) {
-        EXPECT_TRUE(collision.crash_date->value() > date1 && collision.crash_date->value() < date2 &&
-        collision.borough->value() == "MANHATTAN" &&
-        collision.crash_time->has_value() && collision.crash_time->value().to_duration() > crash_time.to_duration() &&
-        collision.number_of_persons_injured->value() > persons_injured)
+    for (const auto *collision : results) {
+        EXPECT_TRUE(collision->crash_date->value() > date1 && collision->crash_date->value() < date2 &&
+        collision->borough->value() == "MANHATTAN" &&
+        collision->crash_time->has_value() && collision->crash_time->value().to_duration() > crash_time.to_duration() &&
+        collision->number_of_persons_injured->value() > persons_injured)
             << "Each result should have dates in between " << date1 << " and " << date2 << " . The crash time is after " << crash_time
             << " . Collisions occurred at borough " << borough << " and number of people injured are " << persons_injured;
     }
@@ -648,16 +648,16 @@ TEST_F(CollisionManagerTest, CompoundQuery_Match_MutipleCollisions) {
     .add("vehicle_type_code_1", QueryType::EQUALS, vehicle_type_code_1)
     .add("vehicle_type_code_2", QueryType::CONTAINS, vehicle_type_code_2);
 
-    std::vector<CollisionProxy> results = collision_manager_m.searchOpenMp(query1);
+    std::vector<CollisionProxy*> results = collision_manager_m.searchOpenMp(query1);
 
     EXPECT_GT(results.size(), 0) << "Search should return at least one result";
 
-    for (const auto collision : results)
+    for (const auto *collision : results)
     {
-        EXPECT_TRUE(collision.borough->value() == borough &&
-        collision.crash_date->value() > date1 && collision.crash_date->value() < date2 &&
-        collision.contributing_factor_vehicle_2->value() == contributing_factor_vehicle_2 &&
-        collision.vehicle_type_code_1->value() == vehicle_type_code_1 || collision.vehicle_type_code_2->has_value() && collision.vehicle_type_code_2->value().find(vehicle_type_code_2) != std::string::npos)
+        EXPECT_TRUE(collision->borough->value() == borough &&
+        collision->crash_date->value() > date1 && collision->crash_date->value() < date2 &&
+        collision->contributing_factor_vehicle_2->value() == contributing_factor_vehicle_2 &&
+        collision->vehicle_type_code_1->value() == vehicle_type_code_1 || collision->vehicle_type_code_2->has_value() && collision->vehicle_type_code_2->value().find(vehicle_type_code_2) != std::string::npos)
             << "Each result should have dates in between " << date1 << " and " << date2 << " . The contributing factor to the collisions is anything " << contributing_factor_vehicle_2
             << " . The vehicles involved are " << vehicle_type_code_1 << " and " << vehicle_type_code_2;
     }
@@ -672,12 +672,12 @@ TEST_F(CollisionManagerTest, Query_Match_VehicleType) {
     std::string vehicle_type_code_2 = "Station Wagon";
     Query query1 = Query::create("vehicle_type_code_2", QueryType::CONTAINS, vehicle_type_code_2);
 
-    std::vector<CollisionProxy> results = collision_manager_m.searchOpenMp(query1);
+    std::vector<CollisionProxy*> results = collision_manager_m.searchOpenMp(query1);
 
     EXPECT_GT(results.size(), 0) << "Search should return at least one result";
 
-    for(const auto collision : results) {
-        EXPECT_TRUE(collision.vehicle_type_code_2->has_value() && collision.vehicle_type_code_2->value().find(vehicle_type_code_2) != std::string::npos) << " Each result should contain " << vehicle_type_code_2;
+    for(const auto *collision : results) {
+        EXPECT_TRUE(collision->vehicle_type_code_2->has_value() && collision->vehicle_type_code_2->value().find(vehicle_type_code_2) != std::string::npos) << " Each result should contain " << vehicle_type_code_2;
     }
 
     std::cout << " Found " << results.size() << " with vehicle_type_code_2 containing " << vehicle_type_code_2;

--- a/phase_3.2/main.cpp
+++ b/phase_3.2/main.cpp
@@ -47,19 +47,21 @@ int main(int argc, char *argv[]) {
     //Query query = Query::create("crash_date", QueryType::LESS_THAN, 1ULL);
     //Query query = Query::create("crash_time", QueryType::LESS_THAN, 1ULL);
 
-    std::vector<CollisionProxy> collisions = collision_manager.searchOpenMp(query3);
-    std::cout << collisions.at(0) << std::endl;
-    std::cout << collisions.at(1) << std::endl;
-    std::cout << collisions.at(2) << std::endl;
-    std::cout << collisions.at(3) << std::endl;
-    std::cout << collisions.at(4) << std::endl;
+    std::vector<CollisionProxy*> collisions = collision_manager.searchOpenMp(query3);
+    std::cout << "Number collisions found: " << collisions.size() << std::endl;
+    std::cout << *collisions.at(0) << std::endl;
+    std::cout << *collisions.at(1) << std::endl;
+    std::cout << *collisions.at(2) << std::endl;
+    std::cout << *collisions.at(3) << std::endl;
+    std::cout << *collisions.at(4) << std::endl;
 
 
     Query query4 = Query::create("borough", Qualifier::NOT, QueryType::EQUALS, "BROOKLYN");
     collisions = collision_manager.searchOpenMp(query4);
-    std::cout << collisions.at(0) << std::endl;
-    std::cout << collisions.at(1) << std::endl;
-    std::cout << collisions.at(2) << std::endl;
-    std::cout << collisions.at(3) << std::endl;
-    std::cout << collisions.at(4) << std::endl;
+    std::cout << "Number collisions found: " << collisions.size() << std::endl;
+    std::cout << *collisions.at(0) << std::endl;
+    std::cout << *collisions.at(1) << std::endl;
+    std::cout << *collisions.at(2) << std::endl;
+    std::cout << *collisions.at(3) << std::endl;
+    std::cout << *collisions.at(4) << std::endl;
 }


### PR DESCRIPTION
When implementing object of arrays API in 3.1, I added the `CollisionProxy` class which was the analogue to the `Collision` pointers returned in `search()`. However, the proxies were being created in the search() function and copied back to the caller. This change instead now pre-computes the creation of these objects and returns pointers to them like the pointers from Phase 2. Using pointers and pre-computing these regains the performance lost in 3.1.

Phase 2:
```
--------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                      Time             CPU   Iterations
--------------------------------------------------------------------------------------------------------------------------------
CollisionManagerBenchmark/SearchSingleStringFieldNoMatches/iterations:50                59170100 ns     48802192 ns           50
CollisionManagerBenchmark/SearchSingleStringFieldSomeMatches/iterations:50              51824694 ns     44598418 ns           50
CollisionManagerBenchmark/SearchSingleSizeTFieldNoMatches/iterations:50                 20625332 ns     18198042 ns           50
CollisionManagerBenchmark/SearchSingleSizeTFieldSomeMatches/iterations:50               21974716 ns     19149174 ns           50
CollisionManagerBenchmark/SearchLatitudeSomeMatches/iterations:50                       23965403 ns     21435684 ns           50
CollisionManagerBenchmark/SearchLongitudeSomeMatches/iterations:50                      24373367 ns     21959926 ns           50
CollisionManagerBenchmark/SearchLesserThanLatitudeSomeMatches/iterations:50             26625801 ns     23896578 ns           50
CollisionManagerBenchmark/SearchGreaterThanLatitudeSomeMatches/iterations:50            39882839 ns     33773636 ns           50
CollisionManagerBenchmark/SearchLesserThanLongitudeSomeMatches/iterations:50            25610223 ns     22782290 ns           50
CollisionManagerBenchmark/SearchGreaterThanLongitudeSomeMatches/iterations:50           40119357 ns     34336230 ns           50
CollisionManagerBenchmark/SearchBorough_LessThanLatitudeSomeMatches/iterations:50       33546433 ns     29808020 ns           50
CollisionManagerBenchmark/SearchRangeofCoordinatesSomeMatches/iterations:50             39798978 ns     35668378 ns           50
CollisionManagerBenchmark/SearchDatesEqualsSomeMatches/iterations:50                    18886118 ns     17144700 ns           50
CollisionManagerBenchmark/SearchDatesRangeSomeMatches/iterations:50                     29931081 ns     27179260 ns           50
CollisionManagerBenchmark/SearchRangeofCoordinates_DateRangeSomeMatches/iterations:50   55670732 ns     49308994 ns           50
```

Phase 3.1 (Regression):
```
--------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                      Time             CPU   Iterations
--------------------------------------------------------------------------------------------------------------------------------
CollisionManagerBenchmark/SearchSingleStringFieldNoMatches/iterations:50                48003875 ns     42022772 ns           50
CollisionManagerBenchmark/SearchSingleStringFieldSomeMatches/iterations:50              95622977 ns     84511372 ns           50
CollisionManagerBenchmark/SearchSingleSizeTFieldNoMatches/iterations:50                 22303499 ns     19455600 ns           50
CollisionManagerBenchmark/SearchSingleSizeTFieldSomeMatches/iterations:50               21818194 ns     19362204 ns           50
CollisionManagerBenchmark/SearchLatitudeSomeMatches/iterations:50                       23562509 ns     21156554 ns           50
CollisionManagerBenchmark/SearchLongitudeSomeMatches/iterations:50                      23488551 ns     21160936 ns           50
CollisionManagerBenchmark/SearchLesserThanLatitudeSomeMatches/iterations:50             51034434 ns     46087010 ns           50
CollisionManagerBenchmark/SearchGreaterThanLatitudeSomeMatches/iterations:50           237525210 ns    210449448 ns           50
CollisionManagerBenchmark/SearchLesserThanLongitudeSomeMatches/iterations:50            23176445 ns     21054338 ns           50
CollisionManagerBenchmark/SearchGreaterThanLongitudeSomeMatches/iterations:50          248014147 ns    220197872 ns           50
CollisionManagerBenchmark/SearchBorough_LessThanLatitudeSomeMatches/iterations:50       40817467 ns     35896440 ns           50
CollisionManagerBenchmark/SearchRangeofCoordinatesSomeMatches/iterations:50             40829428 ns     36661794 ns           50
CollisionManagerBenchmark/SearchDatesEqualsSomeMatches/iterations:50                    21074676 ns     18971700 ns           50
CollisionManagerBenchmark/SearchDatesRangeSomeMatches/iterations:50                     44901568 ns     40818850 ns           50
CollisionManagerBenchmark/SearchRangeofCoordinates_DateRangeSomeMatches/iterations:50   50917086 ns     45409814 ns           50
```

Phase 3.2 (Fixed Regression):
```
--------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                      Time             CPU   Iterations
--------------------------------------------------------------------------------------------------------------------------------
CollisionManagerBenchmark/SearchSingleStringFieldNoMatches/iterations:50                47573769 ns     41375084 ns           50
CollisionManagerBenchmark/SearchSingleStringFieldSomeMatches/iterations:50              46435156 ns     40462156 ns           50
CollisionManagerBenchmark/SearchSingleSizeTFieldNoMatches/iterations:50                 18192266 ns     16448490 ns           50
CollisionManagerBenchmark/SearchSingleSizeTFieldSomeMatches/iterations:50               19132388 ns     17076704 ns           50
CollisionManagerBenchmark/SearchLatitudeSomeMatches/iterations:50                       21325623 ns     19342322 ns           50
CollisionManagerBenchmark/SearchLongitudeSomeMatches/iterations:50                      21945265 ns     19735930 ns           50
CollisionManagerBenchmark/SearchLesserThanLatitudeSomeMatches/iterations:50             28227815 ns     24307094 ns           50
CollisionManagerBenchmark/SearchGreaterThanLatitudeSomeMatches/iterations:50            39451439 ns     35416728 ns           50
CollisionManagerBenchmark/SearchLesserThanLongitudeSomeMatches/iterations:50            21362263 ns     19248958 ns           50
CollisionManagerBenchmark/SearchGreaterThanLongitudeSomeMatches/iterations:50           42479719 ns     37716124 ns           50
CollisionManagerBenchmark/SearchBorough_LessThanLatitudeSomeMatches/iterations:50       29843391 ns     27064922 ns           50
CollisionManagerBenchmark/SearchRangeofCoordinatesSomeMatches/iterations:50             37268266 ns     33686454 ns           50
CollisionManagerBenchmark/SearchDatesEqualsSomeMatches/iterations:50                    18514096 ns     16729688 ns           50
CollisionManagerBenchmark/SearchDatesRangeSomeMatches/iterations:50                     32622618 ns     29654926 ns           50
CollisionManagerBenchmark/SearchRangeofCoordinates_DateRangeSomeMatches/iterations:50   47365274 ns     42606966 ns           50
```