### PR TITLE
Fix collision benchmarks after changing size_t fields

### DIFF
--- a/phase_3.6/collision_manager_benchmark.cpp
+++ b/phase_3.6/collision_manager_benchmark.cpp
@@ -201,9 +201,10 @@ BENCHMARK_DEFINE_F(CollisionManagerBenchmark, SearchRangeofCoordinates_DateRange
 
  // The range we're searching
     float epsilon = 0.01f; // approximately 1 km radius
+    std::uint32_t zip_code = 11208;
 
     Query query = Query::create(CollisionField::BOROUGH, QueryType::EQUALS, borough)
-                       .add(CollisionField::ZIP_CODE, QueryType::EQUALS, 11208ULL)
+                       .add(CollisionField::ZIP_CODE, QueryType::EQUALS, zip_code)
                        .add(CollisionField::LATITUDE, QueryType::GREATER_THAN, latitude - epsilon)
                        .add(CollisionField::LATITUDE, QueryType::LESS_THAN, latitude + epsilon)
                        .add(CollisionField::LONGITUDE, QueryType::GREATER_THAN, longitude - epsilon)

--- a/phase_3.7/collision_manager_benchmark.cpp
+++ b/phase_3.7/collision_manager_benchmark.cpp
@@ -201,9 +201,10 @@ BENCHMARK_DEFINE_F(CollisionManagerBenchmark, SearchRangeofCoordinates_DateRange
 
  // The range we're searching
     float epsilon = 0.01f; // approximately 1 km radius
+    std::uint32_t zip_code = 11208;
 
     Query query = Query::create(CollisionField::BOROUGH, QueryType::EQUALS, borough)
-                       .add(CollisionField::ZIP_CODE, QueryType::EQUALS, 11208ULL)
+                       .add(CollisionField::ZIP_CODE, QueryType::EQUALS, zip_code)
                        .add(CollisionField::LATITUDE, QueryType::GREATER_THAN, latitude - epsilon)
                        .add(CollisionField::LATITUDE, QueryType::LESS_THAN, latitude + epsilon)
                        .add(CollisionField::LONGITUDE, QueryType::GREATER_THAN, longitude - epsilon)


### PR DESCRIPTION
This was causing std::invalid_argument to be thrown